### PR TITLE
User Registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "bootsnap", require: false
 # gem "rack-cors"
 gem "faraday"
 gem "jsonapi-serializer"
+gem "bcrypt", "~> 3.1.7"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bigdecimal (3.1.6)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -267,6 +268,7 @@ PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   capybara
   debug

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+
+    user = User.new(user_params)
+    user.save!  # This will raise ActiveRecord::RecordInvalid if the item is invalid
+    render json: UserSerializer.new(user), status: :created
+  end
+
+private
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,24 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_response 
+  rescue_from ActiveRecord::RecordInvalid, with: :invalid_record_response 
+  rescue_from ActionController::BadRequest, with: :bad_request_response
+
+private
+  # when AR query like find is used and no record of an ID exists 
+  def not_found_response(exception) 
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
+      .serialize_json, status: :not_found
+  end
+
+  # when AR model fail upon saving (save, create, update)
+  def invalid_record_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 422))
+      .serialize_json, status: :unprocessable_entity
+  end
+
+  # when a request can't be processed due to bad parameters
+  def bad_request_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 400))
+      .serialize_json, status: :bad_request
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,15 @@
+class User < ApplicationRecord
+  validates :email, uniqueness: true, presence: true
+  validates_presence_of :name
+  validates_presence_of :password
+
+  has_secure_password
+
+  before_create :generate_api_key
+
+  private
+
+  def generate_api_key
+    self.api_key = SecureRandom.hex(10) # Generates a random hex string
+  end
+end

--- a/app/poros/error_message.rb
+++ b/app/poros/error_message.rb
@@ -1,0 +1,8 @@
+class ErrorMessage
+  attr_reader :message, :status_code
+
+  def initialize(message, status_code)
+    @message = message
+    @status_code = status_code
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,16 @@
+class ErrorSerializer
+  def initialize(error_object)
+    @error_object = error_object
+  end
+
+  def serialize_json
+    {
+      errors: [
+        {
+          status: @error_object.status_code.to_s,
+          title: @error_object.message
+        }
+      ]
+    }
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+include JSONAPI::Serializer
+attributes :name, :email, :api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/recipes', to: 'recipes#index'
       get '/learning_resources', to: 'resources#index'
+      
+      resources :users, only: [:create]
     end
   end
 end

--- a/db/migrate/20240306204736_create_users.rb
+++ b/db/migrate/20240306204736_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240307043602_add_api_key_to_users.rb
+++ b/db/migrate/20240307043602_add_api_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :api_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_03_07_043602) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "api_key"
+  end
+
+end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe "Users" do
+  describe "create a user" do
+    describe "happy path" do
+       it "can create a new user" do
+        user_params = ({
+          name: "Odell",
+          email: "goodboy@ruffruff.com",
+          password: "treats4lyf",
+          password_confirmation: "treats4lyf"
+        })
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        # include header to make sure params are passed as JSON rather than as plain text
+        post "/api/v1/users", headers: headers, params: JSON.generate(user: user_params)
+
+        created_user = User.last
+
+        expect(response).to be_successful
+
+        expect(created_user.name).to eq(user_params[:name])
+        expect(created_user.name).to be_a(String)
+
+        expect(created_user.email).to eq(user_params[:email])
+        expect(created_user.email).to be_a(String)
+
+        expect(created_user.api_key).not_to be_nil
+        expect(created_user.api_key).to be_a(String)
+        expect(created_user.api_key.length).to eq(20) 
+
+       end
+    end
+
+    describe "sad path" do
+      it "must have unique email addresses" do 
+        user1_params = ({
+          name: "Odell",
+          email: "goodboy@ruffruff.com",
+          password: "treats4lyf",
+          password_confirmation: "treats4lyf"
+        })
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        # include header to make sure params are passed as JSON rather than as plain text
+        post "/api/v1/users", headers: headers, params: JSON.generate(user: user1_params)
+
+        user2_params = ({
+          name: "Odell",
+          email: "goodboy@ruffruff.com",
+          password: "treats4lyf",
+          password_confirmation: "treats4lyf"
+        })
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        # include header to make sure params are passed as JSON rather than as plain text
+        post "/api/v1/users", headers: headers, params: JSON.generate(user: user1_params)
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data[:errors]).to be_a(Array)
+        expect(data[:errors].first[:status]).to eq("422")
+        expect(data[:errors].first[:title]).to eq("Validation failed: Email has already been taken")
+      end
+
+      it "must have matching passwords" do 
+        user_params = ({
+          name: "Odell",
+          email: "goodboy@ruffruff.com",
+          password: "treats4lyf",
+          password_confirmation: "not_matching"
+        })
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        # include header to make sure params are passed as JSON rather than as plain text
+        post "/api/v1/users", headers: headers, params: JSON.generate(user: user_params)
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        data = JSON.parse(response.body, symbolize_names: true)
+
+        expect(data[:errors]).to be_a(Array)
+        expect(data[:errors].first[:status]).to eq("422")
+        expect(data[:errors].first[:title]).to eq("Validation failed: Password confirmation doesn't match Password")
+      end
+    end
+  end
+end


### PR DESCRIPTION
API should expose this endpoint:

Request:

POST /api/v1/users
Content-Type: application/json
Accept: application/json

{
  "name": "Odell",
  "email": "goodboy@ruffruff.com",
  "password": "treats4lyf",
  "password_confirmation": "treats4lyf"
}
NOTE: The above JSON object should be sent in the body of the request, not in query params.

Response:

{
  "data": {
    "type": "user",
    "id": "1",
    "attributes": {
      "name": "Odell",
      "email": "goodboy@ruffruff.com",
      "api_key": "jgn983hy48thw9begh98h4539h4"
    }
  }
}
Requirements:

This POST endpoint should NOT call your endpoint like /api/v1/users?name=Odell&email=goodboy@ruffruff.com&password=treats4lyf&password_confirmation=treats4lyf. You must send a JSON payload in the body of the request in Postman, under the address bar, click on “Body”, select “raw”, which will show a dropdown that probably says “Text” in it, choose “JSON” from the list. This is a hard requirement to pass this endpoint!
A successful request creates a user in your database, creates a password digest, and generates a unique API key associated with that user, with a 201 status code.
Use bcrypt to authenticate and create a password digest for a new user.
Email addresses must be unique. If a unique email address is not used for registration, an appropriate error message should be returned in the response.
If passwords do not match, an appropriate error message should be returned in the response.